### PR TITLE
Emulator window is now resized as soon as it is opened

### DIFF
--- a/src/resize_emu.sh
+++ b/src/resize_emu.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-#Wait for device to connect
-adb wait-for-device
+#Wait emulator window
+A=$(wmctrl -l | grep "nexus_5_8.1")
 
-A=$(adb shell getprop sys.boot_completed | tr -d '\r')
-
-while [ "$A" != "1" ]; do
+while [ -z "$A" ]; do
         sleep 2
-        A=$(adb shell getprop sys.boot_completed | tr -d '\r')
+	A=$(wmctrl -l | grep "nexus_5_8.1")
 done
 
 #Device is now connected


### PR DESCRIPTION


### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
Emulator window is now resized as soon as it is opened.
### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
opened the app and the window was correctly sized on emulator bootup
